### PR TITLE
feat: 調整 root log 的 level 為 INFO

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,3 +1,6 @@
+from src.config.logging_config import init_logging
+log = init_logging()
+
 import os
 import asyncio
 from mangum import Mangum

--- a/src/config/exception.py
+++ b/src/config/exception.py
@@ -2,15 +2,15 @@ from fastapi import FastAPI, Request, HTTPException, status
 from fastapi.responses import JSONResponse
 from typing import Any
 from ..router.res.response import res_err_format
-import logging as log
+import logging
 
-log.basicConfig(filemode='w', level=log.INFO)
+log = logging.getLogger(__name__)
 
 
 class ErrorLogger:
     def __init__(self, msg: str):
         log.error(msg)
-        
+
 
 
 class ClientException(HTTPException, ErrorLogger):
@@ -19,17 +19,17 @@ class ClientException(HTTPException, ErrorLogger):
         self.code = code
         self.data = data
         self.status_code = status.HTTP_400_BAD_REQUEST
-        
+
     def __str__(self) -> str:
         return self.msg
-        
+
 class UnauthorizedException(HTTPException, ErrorLogger):
     def __init__(self, msg: str, code: str = '40100', data: Any = None):
         self.msg = msg
         self.code = code
         self.data = data
         self.status_code = status.HTTP_401_UNAUTHORIZED
-        
+
     def __str__(self) -> str:
         return self.msg
 
@@ -39,7 +39,7 @@ class ForbiddenException(HTTPException, ErrorLogger):
         self.code = code
         self.data = data
         self.status_code = status.HTTP_403_FORBIDDEN
-        
+
     def __str__(self) -> str:
         return self.msg
 
@@ -49,17 +49,17 @@ class NotFoundException(HTTPException, ErrorLogger):
         self.code = code
         self.data = data
         self.status_code = status.HTTP_404_NOT_FOUND
-        
+
     def __str__(self) -> str:
         return self.msg
-        
+
 class NotAcceptableException(HTTPException, ErrorLogger):
     def __init__(self, msg: str, code: str = '40600', data: Any = None):
         self.msg = msg
         self.code = code
         self.data = data
         self.status_code = status.HTTP_406_NOT_ACCEPTABLE
-        
+
     def __str__(self) -> str:
         return self.msg
 
@@ -69,27 +69,27 @@ class DuplicateUserException(HTTPException, ErrorLogger):
         self.code = code
         self.data = data
         self.status_code = status.HTTP_406_NOT_ACCEPTABLE
-        
+
     def __str__(self) -> str:
         return self.msg
-        
+
 class TooManyRequestsException(HTTPException, ErrorLogger):
     def __init__(self, msg: str, code: str = '42900', data: Any = None):
         self.msg = msg
         self.code = code
         self.data = data
         self.status_code = status.HTTP_429_TOO_MANY_REQUESTS
-        
+
     def __str__(self) -> str:
         return self.msg
-        
+
 class ServerException(HTTPException, ErrorLogger):
     def __init__(self, msg: str, code: str = '50000', data: Any = None):
         self.msg = msg
         self.code = code
         self.data = data
         self.status_code = status.HTTP_500_INTERNAL_SERVER_ERROR
-        
+
     def __str__(self) -> str:
         return self.msg
 
@@ -134,25 +134,25 @@ def include_app(app: FastAPI):
 def raise_http_exception(e: Exception, msg: str = None):
     if isinstance(e, ClientException):
         raise ClientException(msg=msg or e.msg, data=e.data)
-    
+
     if isinstance(e, UnauthorizedException):
         raise UnauthorizedException(msg=msg or e.msg, data=e.data)
-    
+
     if isinstance(e, ForbiddenException):
         raise ForbiddenException(msg=msg or e.msg, data=e.data)
-        
+
     if isinstance(e, NotFoundException):
         raise NotFoundException(msg=msg or e.msg, data=e.data)
-    
+
     if isinstance(e, NotAcceptableException):
         raise NotAcceptableException(msg=msg or e.msg, data=e.data)
-    
+
     if isinstance(e, DuplicateUserException):
         raise DuplicateUserException(msg=msg or e.msg, data=e.data)
-    
+
     if isinstance(e, ServerException):
         raise ServerException(msg=msg or e.msg, data=e.data)
-    
+
     raise ServerException(msg=msg)
 
 status_code_mapping = {

--- a/src/config/logging_config.py
+++ b/src/config/logging_config.py
@@ -1,0 +1,15 @@
+import logging
+
+def init_logging():
+    """
+    初始化全域 logging 設定
+
+    - 設定 root logger 層級為 INFO
+    - 打印初始化訊息
+    """
+
+    root_logger = logging.getLogger()
+    
+    root_logger.setLevel(logging.INFO)
+
+    root_logger.info("Logging initialized (root level=INFO)")

--- a/src/domain/mentor/model/experience_model.py
+++ b/src/domain/mentor/model/experience_model.py
@@ -2,9 +2,9 @@ import json
 from typing import Any, Dict, List, Optional, Union
 from pydantic import BaseModel
 from ....config.constant import *
-import logging as log
+import logging
 
-log.basicConfig(filemode="w", level=log.INFO)
+log = logging.getLogger(__name__)
 
 
 class ExperienceDTO(BaseModel):

--- a/src/domain/mentor/model/mentor_model.py
+++ b/src/domain/mentor/model/mentor_model.py
@@ -11,9 +11,9 @@ from ...user.model.common_model import (
 from ....config.conf import *
 from ....config.constant import *
 from datetime import datetime, timezone
-import logging as log
+import logging
 
-log.basicConfig(filemode="w", level=log.INFO)
+log = logging.getLogger(__name__)
 
 
 class MentorProfileDTO(ProfileDTO):

--- a/src/domain/search/model/search_model.py
+++ b/src/domain/search/model/search_model.py
@@ -6,10 +6,10 @@ from ...mentor.model.mentor_model import MentorProfileVO
 from ....config.conf import *
 from ....config.constant import *
 from ....config.exception import *
-import logging as log
+import logging
 from dateutil.parser import isoparse
 
-log.basicConfig(filemode="w", level=log.INFO)
+log = logging.getLogger(__name__)
 
 
 class SearchMentorProfileDTO(BaseModel):

--- a/src/domain/search/service/search_service.py
+++ b/src/domain/search/service/search_service.py
@@ -4,9 +4,9 @@ from ....domain.search.model.search_model import *
 from ....config.exception import *
 from ....infra.template.client_response import ClientResponse
 import httpx
-import logging as log
+import logging
 
-log.basicConfig(filemode="w", level=log.INFO)
+log = logging.getLogger(__name__)
 
 
 class SearchService:

--- a/src/domain/user/model/common_model.py
+++ b/src/domain/user/model/common_model.py
@@ -2,9 +2,9 @@ import json
 from typing import Any, Dict, List, Optional, Union
 from pydantic import BaseModel
 from ....config.constant import *
-import logging as log
+import logging
 
-log.basicConfig(filemode="w", level=log.INFO)
+log = logging.getLogger(__name__)
 
 
 class InterestVO(BaseModel):

--- a/src/domain/user/model/user_model.py
+++ b/src/domain/user/model/user_model.py
@@ -3,9 +3,9 @@ from typing import Any, Dict, List, Optional, Union
 from pydantic import BaseModel
 from .common_model import ProfessionVO, InterestListVO
 from ....config.constant import *
-import logging as log
+import logging
 
-log.basicConfig(filemode="w", level=log.INFO)
+log = logging.getLogger(__name__)
 
 
 class ProfileDTO(BaseModel):

--- a/src/infra/api/opensearch.py
+++ b/src/infra/api/opensearch.py
@@ -4,9 +4,9 @@ from src.config.exception import *
 from src.config.conf import *
 from src.router.res.response import *
 from src.infra.template.client_response import ClientResponse
-import logging as log
+import logging
 
-log.basicConfig(filemode="w", level=log.INFO)
+log = logging.getLogger(__name__)
 
 
 def check_response_code(method: str, expected_code: int = 200):

--- a/src/router/v1/search.py
+++ b/src/router/v1/search.py
@@ -14,9 +14,9 @@ from ..res.response import *
 from ...config.conf import *
 from ...config.constant import *
 from ...config.exception import *
-import logging as log
+import logging
 
-log.basicConfig(filemode='w', level=log.INFO)
+log = logging.getLogger(__name__)
 
 
 router = APIRouter(

--- a/src/router/v1/search_internal.py
+++ b/src/router/v1/search_internal.py
@@ -8,9 +8,9 @@ from ..req.search_internal import *
 from ..res.response import *
 from ...config.conf import *
 from ...config.exception import *
-import logging as log
+import logging
 
-log.basicConfig(filemode='w', level=log.INFO)
+log = logging.getLogger(__name__)
 
 
 router = APIRouter(


### PR DESCRIPTION
因為 lambda 會初始化 root log，就可以把 log 導到 cloudwatch，但層級是吃預設的，目前預設是 warning 等級以上才會導過去，所以如果想要讓 info 可以顯示在 cloudwatch，就需要調整 root log 的層級為 info，這樣其他檔案就只要拿到 log，會自動繼承 root log 的設定，不需要特別做其他設定，就可以將 INFO 層級以上的訊息寫到 cloudwatch