### PR TITLE
feat(profile): index and expose avatar_updated_at on mentor docs

### DIFF
--- a/main.py
+++ b/main.py
@@ -45,6 +45,9 @@ app.add_middleware(
 async def startup_event():
     # ensure OpenSearch index exists with the correct mapping
     await _index_initializer.ensure_index("profiles", PROFILES_INDEX_MAPPING)
+    # Apply additive mapping changes (e.g. new fields like avatar_updated_at)
+    # to an existing index. No-op on a freshly-created index above.
+    await _index_initializer.sync_mapping("profiles", PROFILES_INDEX_MAPPING)
 
     # init global connection pool
     await _resource_manager.initial()

--- a/src/domain/user/model/user_model.py
+++ b/src/domain/user/model/user_model.py
@@ -15,6 +15,10 @@ class ProfileDTO(BaseModel):
     user_id: Optional[int]
     name: Optional[str] = ""
     avatar: Optional[str] = ""
+    # Unix epoch seconds; bumped by X-Career-User only when the avatar URL
+    # actually changes. Captured from the SQS UPSERT_MENTOR_PROFILE payload so
+    # the frontend can use it as a cache buster on the stable S3 URL.
+    avatar_updated_at: Optional[int] = None
     job_title: Optional[str] = ""
     company: Optional[str] = ""
     years_of_experience: Optional[str] = "0"
@@ -37,6 +41,7 @@ class ProfileVO(BaseModel):
     user_id: int
     name: Optional[str] = ""
     avatar: Optional[str] = ""
+    avatar_updated_at: Optional[int] = None
     job_title: Optional[str] = ""
     company: Optional[str] = ""
     years_of_experience: Optional[str] = "0"

--- a/src/infra/opensearch/initializer.py
+++ b/src/infra/opensearch/initializer.py
@@ -44,3 +44,44 @@ class IndexInitializer:
         except Exception as e:
             log.error("[IndexInitializer] failed to ensure index '%s': %s", index, e)
             return False
+
+    async def sync_mapping(self, index: str, mapping: Dict) -> bool:
+        """
+        Apply additive mapping changes (new properties) to an existing index.
+
+        OpenSearch's `PUT /<index>/_mapping` accepts new fields without recreating
+        the index, but rejects type changes on existing fields. We rely on that:
+        deploys that introduce a new field (e.g. `avatar_updated_at`) take effect
+        without manual ops; deploys that try to change an existing field's type
+        will surface as a logged error and a no-op rather than a silent drift.
+
+        Returns True when the mapping was applied (or no-op-acknowledged), False
+        on any unexpected failure.
+        """
+        try:
+            properties = mapping.get("mappings", {}).get("properties")
+            if not properties:
+                log.info(
+                    "[IndexInitializer] no properties to sync for index '%s'.", index
+                )
+                return True
+
+            response = self.opensearch.http_client.put(
+                f"/{index}/_mapping",
+                json={"properties": properties},
+            )
+            if response.status_code in (200, 201):
+                log.info(
+                    "[IndexInitializer] mapping for '%s' synced successfully.", index
+                )
+                return True
+
+            log.error(
+                "[IndexInitializer] unexpected response syncing mapping for '%s': status=%s body=%s",
+                index, response.status_code, response.json(),
+            )
+            return False
+
+        except Exception as e:
+            log.error("[IndexInitializer] failed to sync mapping for '%s': %s", index, e)
+            return False

--- a/src/infra/opensearch/mapping.py
+++ b/src/infra/opensearch/mapping.py
@@ -26,6 +26,10 @@ PROFILES_INDEX_MAPPING: Dict = {
                 "fields": {"keyword": {"type": "keyword", "ignore_above": 256}},
             },
             "avatar": {"type": "keyword"},
+            # Unix epoch seconds; bumped only when the avatar URL actually
+            # changes. Mirrors X-Career-User Profile.avatar_updated_at and is
+            # used by the frontend as a cache buster on the stable S3 URL.
+            "avatar_updated_at": {"type": "long"},
             "location": {"type": "keyword"},
             "job_title": {
                 "type": "text",


### PR DESCRIPTION
## Summary

X-Career-BFF already passes `avatar_updated_at` through to `SearchMentorProfileVO` (BFF#109), but the search service never captured the field from the SQS `UPSERT_MENTOR_PROFILE` payload and never indexed it, so the BFF response was always null and the frontend cache buster on mentor-pool / search-mentor cards (Xchange-Taiwan/X-Talent-Tracker#244) never took effect.

### Changes

- **`src/infra/opensearch/mapping.py`** — add `avatar_updated_at: long` to the profiles index mapping (Unix epoch seconds, matching X-Career-User `Profile.avatar_updated_at` which uses `current_seconds()` / `BigInteger`).
- **`src/domain/user/model/user_model.py`** — mirror `avatar_updated_at: Optional[int] = None` on the search-side `ProfileDTO` and `ProfileVO`. `MentorProfileDTO` extends `ProfileDTO` and constructs from `**event`, so the field flows in from the SQS payload automatically. `MentorProfileVO` extends `ProfileVO`, so `SearchMentorProfileVO` exposes the field on `/v1/mentors`.
- **`src/infra/opensearch/initializer.py`** — new `sync_mapping(index, mapping)` helper that issues `PUT /<index>/_mapping`. OpenSearch accepts additive field changes there without recreating the index, but rejects type changes on existing fields, so this is safe to run on every startup.
- **`main.py`** — call `sync_mapping("profiles", PROFILES_INDEX_MAPPING)` right after `ensure_index` so deploys that introduce a new field take effect without a manual op step.

### Sync flow (matches AC: 60-second SLA on avatar bump)

X-Career-User already includes `avatar_updated_at` in the SQS event payload — `MentorProfileVO.from_dto()` and `MentorProfileVO.of()` both forward the field, and the existing `NotifyService.updated_user_profile` fires `UPSERT_MENTOR_PROFILE` after every profile upsert. Once this PR ships, the existing pipeline (User upsert → SQS → `_upsert_mentor` → `send_mentor` → `_update` with `doc_as_upsert`) carries the new field end-to-end. The `to_json()` filter that drops `None` values is fine: when no avatar bump has happened the field is simply absent, and frontend renders the bare URL (matches Xchange-Taiwan/X-Talent-Tracker#244 frontend behavior).

### Backfill (operational)

Existing OpenSearch documents will not have `avatar_updated_at` until either:
1. A profile update fires `UPSERT_MENTOR_PROFILE` again (every existing field on the doc is repopulated, including the new one), or
2. A one-shot republish is triggered from X-Career-User against all mentors.

If we want every existing mentor to have the field on day one, the operational step is to run a User-side bulk republish (separate task — not in this PR). Without that step, the field populates as users edit their profiles, with full coverage once everyone has touched anything mentor-related at least once.

### Acceptance criteria status

- [x] `mentor` index mapping contains `avatar_updated_at` (added to `PROFILES_INDEX_MAPPING` and synced to existing indices on startup)
- [ ] All existing mentor docs carry the field — depends on the operational bulk republish above
- [x] Mentor uploads new avatar → next `UPSERT_MENTOR_PROFILE` carries the new value to the search index (existing pipeline; well under 60s)
- [x] Direct call to BFF `/v1/mentors` exposes `avatar_updated_at` instead of always-null

### Out of scope

- BFF pass-through (X-Career-BFF#109, already shipped)
- Frontend `?v=` wiring (Xchange-Taiwan/X-Talent-Tracker#244 → Xchange-Taiwan/X-Talent-Frontend#563)
- Reservation path (Xchange-Taiwan/X-Talent-Tracker#243 → X-Career-User#78 + X-Career-BFF#111)

Closes Xchange-Taiwan/X-Talent-Tracker#242

## Test plan

- [ ] Deploy to dev, confirm startup logs `mapping for 'profiles' synced successfully`
- [ ] Confirm `GET /profiles/_mapping` on dev OpenSearch shows `avatar_updated_at: { type: long }`
- [ ] Bump a mentor's avatar via the BFF upload flow; within 60s, `GET /profiles/_doc/{user_id}` shows the new `avatar_updated_at`
- [ ] `GET /v1/mentors` via BFF returns `avatar_updated_at` populated for that mentor (instead of null)
- [ ] No regressions on existing mentor list / search query paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)
