### PR TITLE
feat(#229): profiles_v2 index + dual-write + filter_offers (Search)

### DIFF
--- a/main.py
+++ b/main.py
@@ -25,6 +25,7 @@ from src.app._di.injection import (
     _search_service,
     _index_initializer,
     PROFILES_INDEX_MAPPING,
+    PROFILES_V2_INDEX_MAPPING,
 )
 from src.config import exception
 
@@ -43,8 +44,12 @@ app.add_middleware(
 
 @app.on_event("startup")
 async def startup_event():
-    # ensure OpenSearch index exists with the correct mapping
+    # ensure OpenSearch indices exist with the correct mappings.
+    # v1 (`profiles`) is the live alias target; v2 (`profiles_v2`) is the new
+    # unified user_tags index added in #229. Both are populated in parallel
+    # until the v1→v2 alias swap in #233.
     await _index_initializer.ensure_index("profiles", PROFILES_INDEX_MAPPING)
+    await _index_initializer.ensure_index("profiles_v2", PROFILES_V2_INDEX_MAPPING)
 
     # init global connection pool
     await _resource_manager.initial()

--- a/src/app/_di/injection.py
+++ b/src/app/_di/injection.py
@@ -7,6 +7,7 @@ from src.infra.mq.sqs_mq_adapter import SqsMqAdapter
 from src.infra.api.opensearch import OpenSearch
 from src.infra.opensearch.initializer import IndexInitializer
 from src.infra.opensearch.mapping import PROFILES_INDEX_MAPPING
+from src.infra.opensearch.profiles_v2_mapping import PROFILES_V2_INDEX_MAPPING
 from src.domain.search.service.search_service import SearchService
 from src.config.conf import SQS_QUEUE_URL, SQS_DEAD_LETTER_QUEUE_URL
 

--- a/src/domain/mentor/model/mentor_model.py
+++ b/src/domain/mentor/model/mentor_model.py
@@ -23,6 +23,10 @@ class MentorProfileDTO(ProfileDTO):
     seniority_level: Optional[SeniorityLevel] = None
     expertises: Optional[List[str]] = None
     experiences: Optional[List[Dict]] = Field(default_factory=list)
+    # Unified user_tags array for the v2 index (#226 / #229). Each entry is
+    # {tag_id, kind, intent, subject_group, subject?, language?}. Absent on
+    # legacy SQS payloads — v1 doc is unaffected.
+    user_tags: Optional[List[Dict]] = None
     created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
     updated_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
     # SQS routing field – consumed by the Search service command registry;

--- a/src/domain/search/model/search_model.py
+++ b/src/domain/search/model/search_model.py
@@ -19,6 +19,11 @@ class SearchMentorProfileDTO(BaseModel):
     filter_topics: Optional[List[str]]
     filter_expertises: Optional[List[str]]
     filter_industries: Optional[str]
+    # v2 (#229) — matches `user_tags` rows where intent=OFFER and
+    # subject_group is one of the supplied values. kind ∈ {what_i_offer,
+    # expertise} per the #226 design (#229 only mints what_i_offer; expertise
+    # arrives in #231).
+    filter_offers: Optional[List[str]] = None
     limit: int = PAGE_LIMIT
     cursor: Optional[datetime]
 

--- a/src/domain/search/service/search_service.py
+++ b/src/domain/search/service/search_service.py
@@ -64,15 +64,24 @@ class SearchService:
         updated_at.  Does NOT touch any other profile fields."""
         user_id = event.get("user_id")
         experiences = event.get("experiences", [])
+        now_iso = datetime.now(timezone.utc).isoformat()
         patch_body = {
             "doc": {
                 "experiences": experiences,
-                "updated_at": datetime.now(timezone.utc).isoformat(),
+                "updated_at": now_iso,
             }
         }
         response: ClientResponse = await self.opensearch.post(
             f"/profiles/_update/{user_id}", json=patch_body
         )
+        # Mirror the same patch into v2 — best-effort. Don't fail the SQS
+        # callback if v2 is missing the doc (alias swap in #233).
+        try:
+            await self.opensearch.post(
+                f"/profiles_v2/_update/{user_id}", json=patch_body
+            )
+        except Exception as e:
+            log.warning("[SearchService] v2 patch failed for user %s: %s", user_id, e)
         return response.res_json
 
     async def _delete_mentor_by_event(self, event: Dict):
@@ -83,30 +92,54 @@ class SearchService:
     # ── Core OpenSearch operations ────────────────────────────────────────────
 
     async def send_mentor(self, body: MentorProfileDTO):
-        """Upsert a full mentor profile document (create if absent, merge if present)."""
+        """Upsert a full mentor profile document into v1 (`profiles`) and the
+        v2 unified-tag index (`profiles_v2`).
+
+        v1 doc shape is unchanged. v2 doc carries `user_tags` (when the SQS
+        payload includes them) instead of the per-kind nested arrays. Both
+        writes use `doc_as_upsert` so the doc is created on first message.
+        """
         user_id = body.user_id
         body.updated_at = datetime.now(timezone.utc)
         json_doc = body.to_json()
-        upsert_body = {
-            "doc": json_doc,
-            "doc_as_upsert": True,
-        }
-        response: ClientResponse = await self.opensearch.post(
-            f"/profiles/_update/{user_id}", json=upsert_body
+
+        # v1 — strip user_tags, keep legacy nested fields
+        v1_doc = {k: v for k, v in json_doc.items() if k != "user_tags"}
+        v1_response: ClientResponse = await self.opensearch.post(
+            f"/profiles/_update/{user_id}",
+            json={"doc": v1_doc, "doc_as_upsert": True},
         )
-        return response.res_json
+
+        # v2 — strip legacy per-kind nested arrays, keep user_tags. Once the
+        # User-side publisher emits user_tags in every SQS payload (planned
+        # follow-up), v2 docs become authoritative.
+        v2_legacy_keys = {"interested_positions", "skills", "topics", "expertises"}
+        v2_doc = {k: v for k, v in json_doc.items() if k not in v2_legacy_keys}
+        try:
+            await self.opensearch.post(
+                f"/profiles_v2/_update/{user_id}",
+                json={"doc": v2_doc, "doc_as_upsert": True},
+            )
+        except Exception as e:
+            log.warning("[SearchService] v2 upsert failed for user %s: %s", user_id, e)
+
+        return v1_response.res_json
 
     async def delete_mentor(self, user_id: int):
         response: ClientResponse = await self.opensearch.delete(
             f"/profiles/_doc/{user_id}"
         )
+        try:
+            await self.opensearch.delete(f"/profiles_v2/_doc/{user_id}")
+        except Exception as e:
+            log.warning("[SearchService] v2 delete failed for user %s: %s", user_id, e)
         return response.res_json
 
-    async def get_mentor_list(self, query: SearchMentorProfileDTO):
+    async def get_mentor_list(self, query: SearchMentorProfileDTO, index: str = "profiles"):
         if query is None:
             raise ClientException(msg="Query could not be None")
         response: ClientResponse = await self.opensearch.post(
-            f"/profiles/_search",
+            f"/{index}/_search",
             params={"request_cache": "true", "pretty": "true"},
             json=query,
         )

--- a/src/infra/opensearch/profiles_v2_mapping.py
+++ b/src/infra/opensearch/profiles_v2_mapping.py
@@ -1,0 +1,67 @@
+from typing import Dict
+
+
+_USER_TAG_NESTED_PROPS = {
+    "tag_id": {"type": "long"},
+    "kind": {"type": "keyword"},
+    "intent": {"type": "keyword"},
+    "subject_group": {"type": "keyword"},
+    "subject": {
+        "type": "text",
+        "fields": {"keyword": {"type": "keyword", "ignore_above": 256}},
+    },
+    "language": {"type": "keyword"},
+}
+
+
+PROFILES_V2_INDEX_MAPPING: Dict = {
+    "settings": {
+        "number_of_shards": 1,
+        "number_of_replicas": 1,
+    },
+    "mappings": {
+        "properties": {
+            "user_id": {"type": "long"},
+            "name": {
+                "type": "text",
+                "fields": {"keyword": {"type": "keyword", "ignore_above": 256}},
+            },
+            "avatar": {"type": "keyword"},
+            "location": {"type": "keyword"},
+            "job_title": {
+                "type": "text",
+                "fields": {"keyword": {"type": "keyword", "ignore_above": 256}},
+            },
+            "company": {
+                "type": "text",
+                "fields": {"keyword": {"type": "keyword", "ignore_above": 256}},
+            },
+            "years_of_experience": {"type": "keyword"},
+            "industry": {"type": "keyword"},
+            "language": {"type": "keyword"},
+            "is_mentor": {"type": "boolean"},
+
+            "personal_statement": {"type": "text"},
+            "about": {"type": "text"},
+            "seniority_level": {"type": "keyword"},
+
+            "created_at": {"type": "date"},
+            "updated_at": {"type": "date"},
+
+            "user_tags": {
+                "type": "nested",
+                "properties": _USER_TAG_NESTED_PROPS,
+            },
+
+            "experiences": {
+                "type": "nested",
+                "properties": {
+                    "id": {"type": "integer"},
+                    "category": {"type": "keyword"},
+                    "order": {"type": "integer"},
+                    "mentor_experiences_metadata": {"type": "object", "dynamic": True},
+                },
+            },
+        }
+    },
+}

--- a/src/router/req/search.py
+++ b/src/router/req/search.py
@@ -62,6 +62,27 @@ def format_search_mentors_query(
             }
         })
 
+    # v2-only filter — matches user_tags(intent=OFFER, kind∈{what_i_offer,
+    # expertise}, subject_group∈[...]). Caller is expected to route the query
+    # to the `profiles_v2` index when this filter is set.
+    if query.filter_offers:
+        query_body["query"]["bool"]["must"].append({
+            "nested": {
+                "path": "user_tags",
+                "query": {
+                    "bool": {
+                        "must": [
+                            {"term": {"user_tags.intent": "OFFER"}},
+                            {"terms": {"user_tags.subject_group": query.filter_offers}},
+                        ],
+                        "filter": [
+                            {"terms": {"user_tags.kind": ["what_i_offer", "expertise"]}},
+                        ],
+                    }
+                },
+            }
+        })
+
     if query.search_pattern:
         query_body["query"]["bool"]["must"].append(
             {"query_string": {"query": f"*{query.search_pattern}*"}}

--- a/src/router/v1/search.py
+++ b/src/router/v1/search.py
@@ -35,6 +35,7 @@ async def mentor_list(
     filter_topics: List[str] = Query(None),
     filter_expertises: List[str] = Query(None),
     filter_industries: str = Query(None),
+    filter_offers: List[str] = Query(None),
     limit: int = Query(PAGE_LIMIT),
     cursor: datetime = Query(None),
 ):
@@ -45,11 +46,16 @@ async def mentor_list(
         filter_topics=filter_topics,
         filter_expertises=filter_expertises,
         filter_industries=filter_industries,
+        filter_offers=filter_offers,
         limit=limit,
         cursor=cursor
     )
     query = format_search_mentors_query(search_query_dto)
-    res = await _search_service.get_mentor_list(query)
+    # filter_offers is v2-only (nested user_tags query). When present, route
+    # the whole search to profiles_v2; otherwise stay on v1 — preserves
+    # existing v1 behavior for the rest of the filters.
+    index = "profiles_v2" if filter_offers else "profiles"
+    res = await _search_service.get_mentor_list(query, index=index)
     return res_success(data=res, status_code=200)
 
 


### PR DESCRIPTION
## Summary

Brings up the v2 OpenSearch index `profiles_v2` alongside `profiles` (v1) and adds the `filter_offers` search filter for the #229 pilot. v1 stays the live alias target — the alias swap is deferred to #233 cleanup once the frontend has fully cut over.

## What changed

- **New mapping** `src/infra/opensearch/profiles_v2_mapping.py`: unified `user_tags` nested field `(tag_id, kind, intent, subject_group, subject, language)`. Drops the per-kind nested arrays (`interested_positions`, `skills`, `topics`, `expertises`) — they are subsumed by `user_tags` with explicit (kind, intent).
- **`MentorProfileDTO`** extended with optional `user_tags: List[Dict]`. Absent on legacy SQS payloads — v1 doc is unaffected.
- **Dual-write** in `SearchService`:
  - `send_mentor`: writes the same upsert to both indices. v1 strips `user_tags`; v2 strips the legacy per-kind arrays.
  - `delete_mentor`: mirrors deletes to v2.
  - `_patch_mentor_experiences`: mirrors the experiences patch.
  - v2 writes are best-effort (`try/except` + warn-log) so a missing v2 doc doesn't fail the SQS callback during the transition.
- **`IndexInitializer.ensure_index`** is now called for both `profiles` and `profiles_v2` on FastAPI startup.
- **Query builder**: `format_search_mentors_query` adds a `filter_offers` branch emitting a nested `user_tags` query — `intent=OFFER`, `kind ∈ {what_i_offer, expertise}`, `subject_group ∈ supplied list`.
- **Route**: `mentor_list` accepts a new `filter_offers: List[str]` query param. When present, the whole search routes to `profiles_v2`; otherwise it stays on `profiles` — preserves v1 behavior for every existing filter.

## Why kind ∈ {what_i_offer, expertise}

Per the #226 design alignment, both `what_i_offer` and `expertise` are OFFER-intent kinds (a mentor's offerings). #229 is the pilot for `what_i_offer`; `expertise` arrives in #231. `filter_offers` is the unified search filter for both, matching the user-facing semantic of "mentors who offer X".

## Additive only

No v1 endpoint, mapping, or doc shape was modified. Existing `filter_positions / filter_skills / filter_topics / filter_expertises / filter_industries` continue to query `profiles` exactly as before. v2 → v1 cutover is in #233.

## Known follow-up

`profiles_v2` only gets useful `user_tags` once the User service publishes them in its SQS payload (or fires an SQS message on `PUT /tags`). That publisher change lands alongside the BFF proxy + frontend cutover in this issue; until then v2 docs exist with empty `user_tags`, which is harmless.

## Test plan

- [ ] `cd X-Talent-infra && docker compose up -d --build` — service boots cleanly
- [ ] OpenSearch logs show both `profiles` and `profiles_v2` index creation (or "already exists" no-op)
- [ ] Existing `GET /search-service/api/v1/search/mentors?filter_skills=...` still returns same shape (queries v1)
- [ ] `GET /search-service/api/v1/search/mentors?filter_offers=career_coaching` returns 200 (queries v2; empty until publisher lands — that's expected)
- [ ] Posting a mentor profile via `/internal/mentor` still upserts v1 doc; v2 doc also created (`curl /profiles_v2/_doc/{user_id}`)

Refs Xchange-Taiwan/X-Talent-Tracker#229, Xchange-Taiwan/X-Talent-Tracker#226

Generated with [Claude Code](https://claude.com/claude-code)
