### PR TITLE
feat(#230-#232): route per-kind filters to profiles_v2 user_tags (Search)

### DIFF
--- a/src/router/req/search.py
+++ b/src/router/req/search.py
@@ -1,6 +1,98 @@
 from ...domain.search.model.search_model import *
 
 
+def _add_user_tags_filter(query_body: Dict, kind: str, intent: str, subject_groups: List[str]):
+    # Reusable nested user_tags clause for the v2 query builder. Each nested
+    # query matches a row in `profiles_v2.user_tags` whose (kind, intent,
+    # subject_group) all line up.
+    query_body["query"]["bool"]["must"].append({
+        "nested": {
+            "path": "user_tags",
+            "query": {
+                "bool": {
+                    "must": [
+                        {"term": {"user_tags.kind": kind}},
+                        {"term": {"user_tags.intent": intent}},
+                        {"terms": {"user_tags.subject_group": subject_groups}},
+                    ]
+                }
+            },
+        }
+    })
+
+
+def format_search_mentors_query_v2(query: SearchMentorProfileDTO):
+    """v2 (#230-#232) query builder. Emits nested `user_tags` queries for
+    every per-kind filter (skills/topics/positions/expertises/offers) so the
+    Search service can target `profiles_v2`. v1 top-level fields like
+    `industry`, plus `search_pattern` and `cursor`, work the same on both
+    indices and are reused here."""
+    query_body = {
+        "query": {"bool": {"must": [], "filter": []}},
+        "sort": [{"updated_at": "asc"}],
+        "size": query.limit or PAGE_LIMIT,
+    }
+
+    if query.filter_skills:
+        _add_user_tags_filter(query_body, "skill", "WANT", query.filter_skills)
+    if query.filter_topics:
+        _add_user_tags_filter(query_body, "topic", "WANT", query.filter_topics)
+    if query.filter_positions:
+        _add_user_tags_filter(query_body, "position", "WANT", query.filter_positions)
+    if query.filter_expertises:
+        _add_user_tags_filter(query_body, "expertise", "OFFER", query.filter_expertises)
+
+    if query.filter_offers:
+        # `filter_offers` spans kind ∈ {what_i_offer, expertise} per the #226
+        # design — both are OFFER intent, both are "things a mentor offers".
+        query_body["query"]["bool"]["must"].append({
+            "nested": {
+                "path": "user_tags",
+                "query": {
+                    "bool": {
+                        "must": [
+                            {"term": {"user_tags.intent": "OFFER"}},
+                            {"terms": {"user_tags.subject_group": query.filter_offers}},
+                        ],
+                        "filter": [
+                            {"terms": {"user_tags.kind": ["what_i_offer", "expertise"]}}
+                        ],
+                    }
+                },
+            }
+        })
+
+    if query.filter_industries:
+        query_body["query"]["bool"]["must"].append({
+            "query_string": {
+                "default_field": "industry",
+                "query": f"*{query.filter_industries}*",
+            }
+        })
+
+    if query.search_pattern:
+        query_body["query"]["bool"]["must"].append(
+            {"query_string": {"query": f"*{query.search_pattern}*"}}
+        )
+
+    if query.cursor:
+        query_body["query"]["bool"]["filter"].append(
+            {"range": {"updated_at": {"gt": query.cursor.isoformat()}}}
+        )
+
+    if (
+        not query_body["query"]["bool"]["must"]
+        and not query_body["query"]["bool"]["filter"]
+    ):
+        query_body = {
+            "query": {"bool": {"must": []}},
+            "sort": [{"updated_at": "asc"}],
+            "size": query.limit or 9,
+        }
+
+    return query_body
+
+
 def format_search_mentors_query(
     query: SearchMentorProfileDTO
 ):

--- a/src/router/v1/search.py
+++ b/src/router/v1/search.py
@@ -50,11 +50,24 @@ async def mentor_list(
         limit=limit,
         cursor=cursor
     )
-    query = format_search_mentors_query(search_query_dto)
-    # filter_offers is v2-only (nested user_tags query). When present, route
-    # the whole search to profiles_v2; otherwise stay on v1 — preserves
-    # existing v1 behavior for the rest of the filters.
-    index = "profiles_v2" if filter_offers else "profiles"
+    # #230-#232: every per-kind filter (skills/topics/positions/expertises/
+    # offers) targets `profiles_v2.user_tags`. When any is present, route
+    # the entire search to v2 with the v2 query builder. Default browse
+    # (no per-kind filters) stays on v1 — same behavior as before #229,
+    # avoids any change for unfiltered listings.
+    use_v2 = any([
+        filter_skills,
+        filter_topics,
+        filter_positions,
+        filter_expertises,
+        filter_offers,
+    ])
+    if use_v2:
+        query = format_search_mentors_query_v2(search_query_dto)
+        index = "profiles_v2"
+    else:
+        query = format_search_mentors_query(search_query_dto)
+        index = "profiles"
     res = await _search_service.get_mentor_list(query, index=index)
     return res_success(data=res, status_code=200)
 


### PR DESCRIPTION
## Summary

Implements the search-side cutover for **#230** (skill WANT), **#231** (expertise OFFER), and **#232** (position+topic WANT) in one batch — they share the same v2 nested-query mechanic and only diverge in `(kind, intent)` mapping.

## What changed

### `format_search_mentors_query_v2()`

New v2 query builder. Emits a nested `user_tags` query for each per-kind filter, mapping `(kind, intent)` per the #226 design:

| Filter param | kind | intent |
|---|---|---|
| `filter_skills` | `skill` | `WANT` |
| `filter_topics` | `topic` | `WANT` |
| `filter_positions` | `position` | `WANT` |
| `filter_expertises` | `expertise` | `OFFER` |
| `filter_offers` | `what_i_offer` ∪ `expertise` | `OFFER` |

`filter_industries`, `search_pattern`, and `cursor` work the same on both indices and are reused unchanged.

### `mentor_list` route — v2 routing

Routes to `profiles_v2` + the v2 builder whenever **any** per-kind filter is set. Default unfiltered browse stays on `profiles` (v1) — listing behavior for callers that pass no filters is byte-identical to today.

### v1 builder — kept

`format_search_mentors_query` is untouched. The `filter_offers` branch inside it is now unreachable from the route but is left for #233 cleanup to remove.

## Dependencies

- Depends on **User PR #86** (`feat/229-tag-sqs-publisher`) so `profiles_v2.user_tags` is actually populated. Without #86, these queries return empty result sets.
- Frontend cutover for the corresponding pickers ships in a sibling PR.

## Acceptance touched

- #230: `mentor pool 用 skill 過濾仍可用 (已切到 v2 nested query)` ✓
- #231: `mentor pool / 個人頁顯示的 expertise 行為一致 (已切到 v2 nested query)` ✓ (search side; display side is in the frontend PR)
- #232: `mentor matching 用 WANT tag 配對的查詢可運作` ✓

## Test plan

- [ ] `cd X-Talent-infra && docker compose up -d --build`
- [ ] Save tags via `PUT /v1/users/1/tags` (kind=skill, intent=WANT, subject_groups=["typescript"])
- [ ] `GET /search-service/api/v1/search/mentors?filter_skills=typescript` → 200, returns user 1 (queries v2)
- [ ] `GET /search-service/api/v1/search/mentors?filter_industries=tech` → still queries v1 (no per-kind filter)
- [ ] `GET /search-service/api/v1/search/mentors` (no filters) → still queries v1
- [ ] Combined: `?filter_skills=typescript&filter_industries=tech` → queries v2 (industry term applies as top-level; skill applies as nested)

Refs Xchange-Taiwan/X-Talent-Tracker#230, Xchange-Taiwan/X-Talent-Tracker#231, Xchange-Taiwan/X-Talent-Tracker#232, Xchange-Taiwan/X-Talent-Tracker#226

Generated with [Claude Code](https://claude.com/claude-code)
