### PR TITLE
fix(#229): index Tag.desc on profiles_v2.user_tags

### DIFF
--- a/src/infra/opensearch/profiles_v2_mapping.py
+++ b/src/infra/opensearch/profiles_v2_mapping.py
@@ -11,6 +11,10 @@ _USER_TAG_NESTED_PROPS = {
         "fields": {"keyword": {"type": "keyword", "ignore_above": 256}},
     },
     "language": {"type": "keyword"},
+    # Free-form per-tag metadata (icon, display hints, etc.). Mirrors the v1
+    # `_INTEREST_NESTED_PROPS.desc` field, sourced from `Tag.desc` JSONB on
+    # the User service.
+    "desc": {"type": "object", "dynamic": True},
 }
 
 


### PR DESCRIPTION
Mirrors v1 _INTEREST_NESTED_PROPS.desc on the new profiles_v2 user_tags nested mapping. User PR #87 + BFF PR #118 make desc travel through the API + SQS payload; this PR makes OpenSearch actually persist it on the v2 doc.

Note: adding a property to an existing nested type is a non-breaking mapping update but ensure_index is a no-op on existing indices. Local dev is throwaway per the testing memo; #233 will bake the final v2 mapping when the alias swap happens.

Refs Xchange-Taiwan/X-Talent-Tracker#229, Xchange-Taiwan/X-Talent-Tracker#226