### PR TITLE
feat(#226): two-layer mapping + kind consolidation + v2 read default (Search)

### DIFF
--- a/src/domain/search/service/search_service.py
+++ b/src/domain/search/service/search_service.py
@@ -153,8 +153,12 @@ class SearchService:
         return {"mentors": mentors, "next_id": None}
 
     async def get_mentor(self, user_id: int):
+        # #226: read from profiles_v2 so callers see the new user_tags array
+        # (with parent_subject_group). v1 (`profiles`) still receives writes
+        # via dual-write for rollback safety, but is no longer the read path
+        # for single-mentor lookups.
         response: ClientResponse = await self.opensearch.get(
-            f"/profiles/_doc/{user_id}", params={"pretty": "true"}
+            f"/profiles_v2/_doc/{user_id}", params={"pretty": "true"}
         )
         data = response.res_json
         source = data.get("_source", {})

--- a/src/infra/opensearch/profiles_v2_mapping.py
+++ b/src/infra/opensearch/profiles_v2_mapping.py
@@ -15,6 +15,10 @@ _USER_TAG_NESTED_PROPS = {
     # `_INTEREST_NESTED_PROPS.desc` field, sourced from `Tag.desc` JSONB on
     # the User service.
     "desc": {"type": "object", "dynamic": True},
+    # Two-layer hierarchy (#226): NULL on top-level group rows, non-NULL on
+    # leaves. Indexed as keyword so search filters can target group-level
+    # buckets (e.g. "all skills under software_dev") if needed later.
+    "parent_subject_group": {"type": "keyword"},
 }
 
 

--- a/src/router/req/search.py
+++ b/src/router/req/search.py
@@ -40,11 +40,15 @@ def format_search_mentors_query_v2(query: SearchMentorProfileDTO):
     if query.filter_positions:
         _add_user_tags_filter(query_body, "position", "WANT", query.filter_positions)
     if query.filter_expertises:
-        _add_user_tags_filter(query_body, "expertise", "OFFER", query.filter_expertises)
+        # Post-#226 kind-consolidation: mentor expertise lives on the same
+        # skill tree, distinguished by intent=OFFER. The legacy `expertise`
+        # kind was dropped from the User-service TagKind enum.
+        _add_user_tags_filter(query_body, "skill", "OFFER", query.filter_expertises)
 
     if query.filter_offers:
-        # `filter_offers` spans kind ∈ {what_i_offer, expertise} per the #226
-        # design — both are OFFER intent, both are "things a mentor offers".
+        # `filter_offers` matches mentor offerings — intent=OFFER on either
+        # the skill or topic tree. Post-#226 kind consolidation, the legacy
+        # `what_i_offer` and `expertise` kinds no longer exist.
         query_body["query"]["bool"]["must"].append({
             "nested": {
                 "path": "user_tags",
@@ -55,7 +59,7 @@ def format_search_mentors_query_v2(query: SearchMentorProfileDTO):
                             {"terms": {"user_tags.subject_group": query.filter_offers}},
                         ],
                         "filter": [
-                            {"terms": {"user_tags.kind": ["what_i_offer", "expertise"]}}
+                            {"terms": {"user_tags.kind": ["skill", "topic"]}}
                         ],
                     }
                 },
@@ -154,26 +158,9 @@ def format_search_mentors_query(
             }
         })
 
-    # v2-only filter — matches user_tags(intent=OFFER, kind∈{what_i_offer,
-    # expertise}, subject_group∈[...]). Caller is expected to route the query
-    # to the `profiles_v2` index when this filter is set.
-    if query.filter_offers:
-        query_body["query"]["bool"]["must"].append({
-            "nested": {
-                "path": "user_tags",
-                "query": {
-                    "bool": {
-                        "must": [
-                            {"term": {"user_tags.intent": "OFFER"}},
-                            {"terms": {"user_tags.subject_group": query.filter_offers}},
-                        ],
-                        "filter": [
-                            {"terms": {"user_tags.kind": ["what_i_offer", "expertise"]}},
-                        ],
-                    }
-                },
-            }
-        })
+    # `filter_offers` is now v2-only; this v1 builder is unreachable for it
+    # (route forces v2 routing whenever filter_offers is set). Removed in this
+    # PR alongside the kind consolidation; the v2 builder is the sole owner.
 
     if query.search_pattern:
         query_body["query"]["bool"]["must"].append(


### PR DESCRIPTION
Mirrors User PR #88 + BFF PR #119. profiles_v2 mapping adds parent_subject_group keyword. v2 query builder follows kind consolidation (filter_expertises now kind=skill+OFFER, filter_offers now kind in {skill,topic}+OFFER). v1 filter_offers branch removed (unreachable). get_mentor switches to read profiles_v2.

Refs Xchange-Taiwan/X-Talent-Tracker#226