### PR TITLE
chore(#226): trim feature-branch comments to load-bearing WHY only

### DIFF
--- a/main.py
+++ b/main.py
@@ -44,10 +44,7 @@ app.add_middleware(
 
 @app.on_event("startup")
 async def startup_event():
-    # ensure OpenSearch indices exist with the correct mappings.
-    # v1 (`profiles`) is the live alias target; v2 (`profiles_v2`) is the new
-    # unified user_tags index added in #229. Both are populated in parallel
-    # until the v1→v2 alias swap in #233.
+    # ensure OpenSearch indices exist with the correct mappings
     await _index_initializer.ensure_index("profiles", PROFILES_INDEX_MAPPING)
     await _index_initializer.ensure_index("profiles_v2", PROFILES_V2_INDEX_MAPPING)
 

--- a/src/domain/mentor/model/mentor_model.py
+++ b/src/domain/mentor/model/mentor_model.py
@@ -23,9 +23,8 @@ class MentorProfileDTO(ProfileDTO):
     seniority_level: Optional[SeniorityLevel] = None
     expertises: Optional[List[str]] = None
     experiences: Optional[List[Dict]] = Field(default_factory=list)
-    # Unified user_tags array for the v2 index (#226 / #229). Each entry is
-    # {tag_id, kind, intent, subject_group, subject?, language?}. Absent on
-    # legacy SQS payloads — v1 doc is unaffected.
+    # Each entry: {tag_id, kind, intent, subject_group, subject?, language?}.
+    # Written to profiles_v2 only; v1 docs ignore this field.
     user_tags: Optional[List[Dict]] = None
     created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
     updated_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))

--- a/src/domain/search/model/search_model.py
+++ b/src/domain/search/model/search_model.py
@@ -19,10 +19,6 @@ class SearchMentorProfileDTO(BaseModel):
     filter_topics: Optional[List[str]]
     filter_expertises: Optional[List[str]]
     filter_industries: Optional[str]
-    # v2 (#229) — matches `user_tags` rows where intent=OFFER and
-    # subject_group is one of the supplied values. kind ∈ {what_i_offer,
-    # expertise} per the #226 design (#229 only mints what_i_offer; expertise
-    # arrives in #231).
     filter_offers: Optional[List[str]] = None
     limit: int = PAGE_LIMIT
     cursor: Optional[datetime]

--- a/src/domain/search/service/search_service.py
+++ b/src/domain/search/service/search_service.py
@@ -74,8 +74,7 @@ class SearchService:
         response: ClientResponse = await self.opensearch.post(
             f"/profiles/_update/{user_id}", json=patch_body
         )
-        # Mirror the same patch into v2 — best-effort. Don't fail the SQS
-        # callback if v2 is missing the doc (alias swap in #233).
+        # Mirror into v2 best-effort; v2 may not yet have the doc.
         try:
             await self.opensearch.post(
                 f"/profiles_v2/_update/{user_id}", json=patch_body
@@ -92,27 +91,19 @@ class SearchService:
     # ── Core OpenSearch operations ────────────────────────────────────────────
 
     async def send_mentor(self, body: MentorProfileDTO):
-        """Upsert a full mentor profile document into v1 (`profiles`) and the
-        v2 unified-tag index (`profiles_v2`).
-
-        v1 doc shape is unchanged. v2 doc carries `user_tags` (when the SQS
-        payload includes them) instead of the per-kind nested arrays. Both
-        writes use `doc_as_upsert` so the doc is created on first message.
-        """
+        """Upsert a full mentor profile document into both `profiles` (v1) and
+        `profiles_v2`. v1 receives the legacy per-kind nested arrays; v2
+        receives `user_tags` instead."""
         user_id = body.user_id
         body.updated_at = datetime.now(timezone.utc)
         json_doc = body.to_json()
 
-        # v1 — strip user_tags, keep legacy nested fields
         v1_doc = {k: v for k, v in json_doc.items() if k != "user_tags"}
         v1_response: ClientResponse = await self.opensearch.post(
             f"/profiles/_update/{user_id}",
             json={"doc": v1_doc, "doc_as_upsert": True},
         )
 
-        # v2 — strip legacy per-kind nested arrays, keep user_tags. Once the
-        # User-side publisher emits user_tags in every SQS payload (planned
-        # follow-up), v2 docs become authoritative.
         v2_legacy_keys = {"interested_positions", "skills", "topics", "expertises"}
         v2_doc = {k: v for k, v in json_doc.items() if k not in v2_legacy_keys}
         try:
@@ -153,10 +144,8 @@ class SearchService:
         return {"mentors": mentors, "next_id": None}
 
     async def get_mentor(self, user_id: int):
-        # #226: read from profiles_v2 so callers see the new user_tags array
-        # (with parent_subject_group). v1 (`profiles`) still receives writes
-        # via dual-write for rollback safety, but is no longer the read path
-        # for single-mentor lookups.
+        # Reads target profiles_v2 so callers receive the user_tags array;
+        # writes still dual-write to profiles for rollback safety.
         response: ClientResponse = await self.opensearch.get(
             f"/profiles_v2/_doc/{user_id}", params={"pretty": "true"}
         )

--- a/src/infra/opensearch/profiles_v2_mapping.py
+++ b/src/infra/opensearch/profiles_v2_mapping.py
@@ -11,13 +11,10 @@ _USER_TAG_NESTED_PROPS = {
         "fields": {"keyword": {"type": "keyword", "ignore_above": 256}},
     },
     "language": {"type": "keyword"},
-    # Free-form per-tag metadata (icon, display hints, etc.). Mirrors the v1
-    # `_INTEREST_NESTED_PROPS.desc` field, sourced from `Tag.desc` JSONB on
-    # the User service.
+    # Free-form per-tag metadata (icon, display hints, etc.).
     "desc": {"type": "object", "dynamic": True},
-    # Two-layer hierarchy (#226): NULL on top-level group rows, non-NULL on
-    # leaves. Indexed as keyword so search filters can target group-level
-    # buckets (e.g. "all skills under software_dev") if needed later.
+    # NULL on top-level group rows, non-NULL on leaves. Keyword so filters
+    # can target group-level buckets.
     "parent_subject_group": {"type": "keyword"},
 }
 

--- a/src/router/req/search.py
+++ b/src/router/req/search.py
@@ -2,9 +2,6 @@ from ...domain.search.model.search_model import *
 
 
 def _add_user_tags_filter(query_body: Dict, kind: str, intent: str, subject_groups: List[str]):
-    # Reusable nested user_tags clause for the v2 query builder. Each nested
-    # query matches a row in `profiles_v2.user_tags` whose (kind, intent,
-    # subject_group) all line up.
     query_body["query"]["bool"]["must"].append({
         "nested": {
             "path": "user_tags",
@@ -22,11 +19,9 @@ def _add_user_tags_filter(query_body: Dict, kind: str, intent: str, subject_grou
 
 
 def format_search_mentors_query_v2(query: SearchMentorProfileDTO):
-    """v2 (#230-#232) query builder. Emits nested `user_tags` queries for
-    every per-kind filter (skills/topics/positions/expertises/offers) so the
-    Search service can target `profiles_v2`. v1 top-level fields like
-    `industry`, plus `search_pattern` and `cursor`, work the same on both
-    indices and are reused here."""
+    """Query builder targeting `profiles_v2`. Per-kind filters become nested
+    `user_tags` queries; top-level fields (industry, search_pattern, cursor)
+    behave the same as on v1."""
     query_body = {
         "query": {"bool": {"must": [], "filter": []}},
         "sort": [{"updated_at": "asc"}],
@@ -40,15 +35,11 @@ def format_search_mentors_query_v2(query: SearchMentorProfileDTO):
     if query.filter_positions:
         _add_user_tags_filter(query_body, "position", "WANT", query.filter_positions)
     if query.filter_expertises:
-        # Post-#226 kind-consolidation: mentor expertise lives on the same
-        # skill tree, distinguished by intent=OFFER. The legacy `expertise`
-        # kind was dropped from the User-service TagKind enum.
+        # Mentor expertise = skill tag with intent=OFFER.
         _add_user_tags_filter(query_body, "skill", "OFFER", query.filter_expertises)
 
     if query.filter_offers:
-        # `filter_offers` matches mentor offerings — intent=OFFER on either
-        # the skill or topic tree. Post-#226 kind consolidation, the legacy
-        # `what_i_offer` and `expertise` kinds no longer exist.
+        # Mentor offerings: intent=OFFER on either the skill or topic tree.
         query_body["query"]["bool"]["must"].append({
             "nested": {
                 "path": "user_tags",
@@ -157,10 +148,6 @@ def format_search_mentors_query(
                 "query": f"*{query.filter_industries}*"
             }
         })
-
-    # `filter_offers` is now v2-only; this v1 builder is unreachable for it
-    # (route forces v2 routing whenever filter_offers is set). Removed in this
-    # PR alongside the kind consolidation; the v2 builder is the sole owner.
 
     if query.search_pattern:
         query_body["query"]["bool"]["must"].append(

--- a/src/router/v1/search.py
+++ b/src/router/v1/search.py
@@ -50,11 +50,9 @@ async def mentor_list(
         limit=limit,
         cursor=cursor
     )
-    # #230-#232: every per-kind filter (skills/topics/positions/expertises/
-    # offers) targets `profiles_v2.user_tags`. When any is present, route
-    # the entire search to v2 with the v2 query builder. Default browse
-    # (no per-kind filters) stays on v1 — same behavior as before #229,
-    # avoids any change for unfiltered listings.
+    # Per-kind filters live on profiles_v2.user_tags, so any filtered query
+    # routes to v2. Unfiltered browse stays on v1 to avoid changing default
+    # listing behavior.
     use_v2 = any([
         filter_skills,
         filter_topics,


### PR DESCRIPTION
## Summary
Pure comment / docstring cleanup. Same criteria as User and BFF cleanup PRs.

### Kept (load-bearing WHY)
- `user_tags` shape note on the `List[Dict]` field (type alone is opaque)
- `parent_subject_group` leaf/group invariant + `keyword` analyzer rationale in `profiles_v2_mapping`
- v1 fallback rationale in the search router (unfiltered browse stays on v1)
- `get_mentor` `profiles` vs `profiles_v2` read/write asymmetry note

No code semantics changed. Pre-existing comments untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)