### PR TITLE
feat(#226): flat keyword[] buckets, plain terms filters

### DIFF
--- a/src/domain/mentor/model/mentor_model.py
+++ b/src/domain/mentor/model/mentor_model.py
@@ -23,6 +23,15 @@ class MentorProfileDTO(ProfileDTO):
     seniority_level: Optional[SeniorityLevel] = None
     expertises: Optional[List[str]] = None
     experiences: Optional[List[Dict]] = Field(default_factory=list)
+
+    # Five flat subject_group arrays from the User-service SQS payload —
+    # each maps 1:1 to a keyword[] field in the OpenSearch mapping.
+    want_position: Optional[List[str]] = None
+    want_skill: Optional[List[str]] = None
+    want_topic: Optional[List[str]] = None
+    have_skill: Optional[List[str]] = None
+    have_topic: Optional[List[str]] = None
+
     created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
     updated_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
     # SQS routing field – consumed by the Search service command registry;

--- a/src/domain/search/model/search_model.py
+++ b/src/domain/search/model/search_model.py
@@ -19,6 +19,7 @@ class SearchMentorProfileDTO(BaseModel):
     filter_topics: Optional[List[str]]
     filter_expertises: Optional[List[str]]
     filter_industries: Optional[str]
+    filter_offers: Optional[List[str]] = None
     limit: int = PAGE_LIMIT
     cursor: Optional[datetime]
 

--- a/src/domain/search/service/search_service.py
+++ b/src/domain/search/service/search_service.py
@@ -64,10 +64,11 @@ class SearchService:
         updated_at.  Does NOT touch any other profile fields."""
         user_id = event.get("user_id")
         experiences = event.get("experiences", [])
+        now_iso = datetime.now(timezone.utc).isoformat()
         patch_body = {
             "doc": {
                 "experiences": experiences,
-                "updated_at": datetime.now(timezone.utc).isoformat(),
+                "updated_at": now_iso,
             }
         }
         response: ClientResponse = await self.opensearch.post(
@@ -83,16 +84,14 @@ class SearchService:
     # ── Core OpenSearch operations ────────────────────────────────────────────
 
     async def send_mentor(self, body: MentorProfileDTO):
-        """Upsert a full mentor profile document (create if absent, merge if present)."""
+        """Upsert a full mentor profile document into the `profiles` index."""
         user_id = body.user_id
         body.updated_at = datetime.now(timezone.utc)
-        json_doc = body.to_json()
-        upsert_body = {
-            "doc": json_doc,
-            "doc_as_upsert": True,
-        }
+        doc = body.to_json()
+
         response: ClientResponse = await self.opensearch.post(
-            f"/profiles/_update/{user_id}", json=upsert_body
+            f"/profiles/_update/{user_id}",
+            json={"doc": doc, "doc_as_upsert": True},
         )
         return response.res_json
 
@@ -106,7 +105,7 @@ class SearchService:
         if query is None:
             raise ClientException(msg="Query could not be None")
         response: ClientResponse = await self.opensearch.post(
-            f"/profiles/_search",
+            "/profiles/_search",
             params={"request_cache": "true", "pretty": "true"},
             json=query,
         )

--- a/src/infra/opensearch/mapping.py
+++ b/src/infra/opensearch/mapping.py
@@ -1,16 +1,17 @@
 from typing import Dict
 
-_INTEREST_NESTED_PROPS = {
-    "id": {"type": "integer"},
-    "subject": {
-        "type": "text",
-        "fields": {"keyword": {"type": "keyword", "ignore_above": 256}},
-    },
-    "subject_group": {"type": "keyword"},
-    "category": {"type": "keyword"},
-    "language": {"type": "keyword"},
-    "desc": {"type": "object", "dynamic": True},
-}
+
+# Five flat keyword[] arrays mirror the buckets exposed on
+# MentorProfileVO/DTO at the User service. Filters are simple `terms`
+# matches on the canonical subject_group key — no nesting needed.
+_BUCKET_FIELDS = (
+    "want_position",
+    "want_skill",
+    "want_topic",
+    "have_skill",
+    "have_topic",
+)
+
 
 PROFILES_INDEX_MAPPING: Dict = {
     "settings": {
@@ -19,7 +20,6 @@ PROFILES_INDEX_MAPPING: Dict = {
     },
     "mappings": {
         "properties": {
-            # ── base profile ────────────────────────────────────────────
             "user_id": {"type": "long"},
             "name": {
                 "type": "text",
@@ -40,53 +40,20 @@ PROFILES_INDEX_MAPPING: Dict = {
             "language": {"type": "keyword"},
             "is_mentor": {"type": "boolean"},
 
-            # ── mentor-specific ─────────────────────────────────────────
             "personal_statement": {"type": "text"},
             "about": {"type": "text"},
             "seniority_level": {"type": "keyword"},
 
-            # ── timestamps ──────────────────────────────────────────────
             "created_at": {"type": "date"},
             "updated_at": {"type": "date"},
 
-            # ── nested: interests ────────────────────────────────────────
-            "interested_positions": {
-                "type": "nested",
-                "properties": _INTEREST_NESTED_PROPS,
-            },
-            "skills": {
-                "type": "nested",
-                "properties": _INTEREST_NESTED_PROPS,
-            },
-            "topics": {
-                "type": "nested",
-                "properties": _INTEREST_NESTED_PROPS,
-            },
+            **{field: {"type": "keyword"} for field in _BUCKET_FIELDS},
 
-            # ── nested: expertises (professions) ─────────────────────────
-            "expertises": {
-                "type": "nested",
-                "properties": {
-                    "id": {"type": "integer"},
-                    "subject": {
-                        "type": "text",
-                        "fields": {"keyword": {"type": "keyword", "ignore_above": 256}},
-                    },
-                    "subject_group": {"type": "keyword"},
-                    "category": {"type": "keyword"},
-                    "language": {"type": "keyword"},
-                    "profession_metadata": {"type": "object", "dynamic": True},
-                },
-            },
-
-            # ── nested: mentor_experiences ────────────────────────────────
-            # Declared as `nested` (not `object`) so each experience item can be
-            # queried independently (e.g. filter by category + metadata together).
             "experiences": {
                 "type": "nested",
                 "properties": {
                     "id": {"type": "integer"},
-                    "category": {"type": "keyword"},  # WORK / EDUCATION / LINK
+                    "category": {"type": "keyword"},
                     "order": {"type": "integer"},
                     "mentor_experiences_metadata": {"type": "object", "dynamic": True},
                 },

--- a/src/router/req/search.py
+++ b/src/router/req/search.py
@@ -1,64 +1,50 @@
 from ...domain.search.model.search_model import *
 
 
-def format_search_mentors_query(
-    query: SearchMentorProfileDTO
-):
-
-    # Initialize the base query body
+def format_search_mentors_query(query: SearchMentorProfileDTO):
+    """Per-bucket filters land on the matching keyword[] field on the root
+    document; industry / search_pattern / cursor stay where they were."""
     query_body = {
-        "query": {
-            "bool": {
-                "must": [],
-                "filter": []
-            }
-        },
-        "sort": [
-            { "updated_at": "asc" }
-        ],
-        "size": query.limit or PAGE_LIMIT
+        "query": {"bool": {"must": [], "filter": []}},
+        "sort": [{"updated_at": "asc"}],
+        "size": query.limit or PAGE_LIMIT,
     }
 
-    # Conditionally add query_string filters
-    if query.filter_positions:
-        query_body["query"]["bool"]["must"].append({
-            "query_string": {
-                "default_field": "interested_positions",
-                "query": " AND ".join(query.filter_positions)
-            }
-        })
-
     if query.filter_skills:
-        query_body["query"]["bool"]["must"].append({
-            "query_string": {
-                "default_field": "skills",
-                "query": " AND ".join(query.filter_skills)
-            }
-        })
-
-    if query.filter_topics:
-        query_body["query"]["bool"]["must"].append({
-            "query_string": {
-                "default_field": "topics",
-                "query": " AND ".join(query.filter_topics)
-            }
-        })
-
-    if query.filter_expertises:
         query_body["query"]["bool"]["must"].append(
-            {
-                "query_string": {
-                    "default_field": "expertises",
-                    "query": " AND ".join(query.filter_expertises),
-                }
-            }
+            {"terms": {"want_skill": query.filter_skills}}
         )
+    if query.filter_topics:
+        query_body["query"]["bool"]["must"].append(
+            {"terms": {"want_topic": query.filter_topics}}
+        )
+    if query.filter_positions:
+        query_body["query"]["bool"]["must"].append(
+            {"terms": {"want_position": query.filter_positions}}
+        )
+    if query.filter_expertises:
+        # Mentor expertise = HAVE-side skill bucket.
+        query_body["query"]["bool"]["must"].append(
+            {"terms": {"have_skill": query.filter_expertises}}
+        )
+
+    if query.filter_offers:
+        # "What I offer" spans both HAVE buckets — match either.
+        query_body["query"]["bool"]["must"].append({
+            "bool": {
+                "should": [
+                    {"terms": {"have_skill": query.filter_offers}},
+                    {"terms": {"have_topic": query.filter_offers}},
+                ],
+                "minimum_should_match": 1,
+            }
+        })
 
     if query.filter_industries:
         query_body["query"]["bool"]["must"].append({
             "query_string": {
                 "default_field": "industry",
-                "query": f"*{query.filter_industries}*"
+                "query": f"*{query.filter_industries}*",
             }
         })
 
@@ -71,15 +57,15 @@ def format_search_mentors_query(
         query_body["query"]["bool"]["filter"].append(
             {"range": {"updated_at": {"gt": query.cursor.isoformat()}}}
         )
-        # query_body["search_after"] = [query.cursor, query.last_id]
 
-    # Check if there are any filters added
     if (
         not query_body["query"]["bool"]["must"]
         and not query_body["query"]["bool"]["filter"]
     ):
-        # or use an empty query like { "query": { "match_all": {} } }
-        # query_body = None
-        query_body = {"query": {"bool": {"must": []}}, "sort": [{ "updated_at": "asc" }], "size": query.limit or 9}
+        query_body = {
+            "query": {"bool": {"must": []}},
+            "sort": [{"updated_at": "asc"}],
+            "size": query.limit or 9,
+        }
 
     return query_body

--- a/src/router/v1/search.py
+++ b/src/router/v1/search.py
@@ -35,6 +35,7 @@ async def mentor_list(
     filter_topics: List[str] = Query(None),
     filter_expertises: List[str] = Query(None),
     filter_industries: str = Query(None),
+    filter_offers: List[str] = Query(None),
     limit: int = Query(PAGE_LIMIT),
     cursor: datetime = Query(None),
 ):
@@ -45,6 +46,7 @@ async def mentor_list(
         filter_topics=filter_topics,
         filter_expertises=filter_expertises,
         filter_industries=filter_industries,
+        filter_offers=filter_offers,
         limit=limit,
         cursor=cursor
     )


### PR DESCRIPTION
## Summary
Replaces nested `user_tags` mapping with five flat `keyword[]` fields. Plain `terms` filters; `filter_offers` becomes `bool.should` over `have_skill` + `have_topic`. DTO consumes flat subject_group arrays from the new SQS payload.

**Do NOT merge — testing pending.** Only `python -m py_compile` was run; no OpenSearch reindex test.

## Pre-deploy
Re-create `profiles` OpenSearch index with the new mapping.

Pairs with X-Career-User and X-Career-BFF.

🤖 Generated with [Claude Code](https://claude.com/claude-code)