### PR TITLE
chore(#226): cleanup legacy v1 tag surface

### DIFF
--- a/src/config/constant.py
+++ b/src/config/constant.py
@@ -6,14 +6,7 @@ class Language(Enum):
     ZH_TW = 'zh_TW'
 
 
-class InterestCategory(Enum):
-    INTERESTED_POSITION = 'INTERESTED_POSITION'
-    SKILL = 'SKILL'
-    TOPIC = 'TOPIC'
-
-
 class ProfessionCategory(Enum):
-    EXPERTISE = 'EXPERTISE'
     INDUSTRY = 'INDUSTRY'
 
 

--- a/src/domain/mentor/model/mentor_model.py
+++ b/src/domain/mentor/model/mentor_model.py
@@ -8,7 +8,6 @@ from fastapi.encoders import jsonable_encoder
 from pydantic import BaseModel, Field
 
 from .experience_model import ExperienceVO
-from ...user.model.common_model import ProfessionListVO
 from ...user.model.user_model import ProfileDTO, ProfileVO
 from ....config.constant import SeniorityLevel, MentorAction
 
@@ -21,7 +20,6 @@ class MentorProfileDTO(ProfileDTO):
     personal_statement: Optional[str] = None
     about: Optional[str] = None
     seniority_level: Optional[SeniorityLevel] = None
-    expertises: Optional[List[str]] = None
     experiences: Optional[List[Dict]] = Field(default_factory=list)
 
     # Five flat subject_group arrays from the User-service SQS payload —
@@ -75,5 +73,4 @@ class MentorProfileVO(ProfileVO):
     personal_statement: Optional[str] = ""
     about: Optional[str] = ""
     seniority_level: Optional[SeniorityLevel] = SeniorityLevel.NO_REVEAL
-    expertises: Optional[ProfessionListVO] = None
     experiences: Optional[List[ExperienceVO]] = Field(default_factory=list)

--- a/src/domain/search/service/search_service.py
+++ b/src/domain/search/service/search_service.py
@@ -54,8 +54,8 @@ class SearchService:
 
     async def _put_mentor(self, event: Dict):
         """Update mentor-specific fields (personal_statement, about, seniority_level,
-        expertises).  Uses the same _update + doc_as_upsert path so OpenSearch merges
-        only the supplied fields."""
+        tag buckets).  Uses the same _update + doc_as_upsert path so OpenSearch
+        merges only the supplied fields."""
         body = MentorProfileDTO(**event)
         await self.send_mentor(body)
 

--- a/src/domain/user/model/common_model.py
+++ b/src/domain/user/model/common_model.py
@@ -1,24 +1,9 @@
-import json
-from typing import Any, Dict, List, Optional, Union
+from typing import Dict, List, Optional
 from pydantic import BaseModel
 from ....config.constant import *
 import logging
 
 log = logging.getLogger(__name__)
-
-
-class InterestVO(BaseModel):
-    id: int
-    category: InterestCategory = None
-    language: Optional[str] = None
-    subject_group: str = "unknown"
-    subject: Optional[str] = ""
-    desc: Optional[Dict] = {}
-
-
-class InterestListVO(BaseModel):
-    interests: List[InterestVO] = []
-    language: Optional[str] = None
 
 
 class ProfessionDTO(BaseModel):

--- a/src/domain/user/model/user_model.py
+++ b/src/domain/user/model/user_model.py
@@ -1,9 +1,9 @@
 import logging
-from typing import List, Optional
+from typing import Optional
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel
 
-from .common_model import ProfessionVO, InterestListVO
+from .common_model import ProfessionVO
 from ....config.conf import DEFAULT_LANGUAGE
 
 log = logging.getLogger(__name__)
@@ -19,9 +19,6 @@ class ProfileDTO(BaseModel):
     company: Optional[str] = ""
     years_of_experience: Optional[str] = "0"
     location: Optional[str] = ""
-    interested_positions: Optional[List[str]] = Field(default_factory=list)
-    skills: Optional[List[str]] = Field(default_factory=list)
-    topics: Optional[List[str]] = Field(default_factory=list)
     industry: Optional[str] = ""
     language: Optional[str] = DEFAULT_LANGUAGE
     is_mentor: Optional[bool] = False
@@ -41,9 +38,6 @@ class ProfileVO(BaseModel):
     company: Optional[str] = ""
     years_of_experience: Optional[str] = "0"
     location: Optional[str] = ""
-    interested_positions: Optional[InterestListVO] = None
-    skills: Optional[InterestListVO] = None
-    topics: Optional[InterestListVO] = None
     industry: Optional[ProfessionVO] = None
     onboarding: Optional[bool] = False
     is_mentor: Optional[bool] = False


### PR DESCRIPTION
## Summary

- Sweeps residual references to the dropped fragmented tag system from Search after the OS mapping flip to flat `keyword[]` buckets in `a4d43ff`.
- The OpenSearch mapping itself was already clean (the 5 flat bucket fields + industry + experiences) — this PR just trims the DTO mirror + constants so Search no longer carries dead types.

### Changes
- `constant.py`: drop `InterestCategory`, `ProfessionCategory.EXPERTISE`
- `user_model`: drop `interested_positions / skills / topics` from `ProfileDTO` + `ProfileVO` (and the `InterestListVO` import)
- `common_model`: drop `InterestVO` / `InterestListVO`
- `mentor_model`: drop `expertises` field from `MentorProfileDTO` + `VO`, drop now-unused `ProfessionListVO` import
- `search_service`: trim stale comment referencing `expertises`

`filter_expertises` is intentionally kept on the search router (still maps to `have_skill` in the query builder); revisit when frontend moves to `filter_offers` exclusively.

## Test plan

- [ ] Reviewer: `python -m compileall src` clean
- [ ] After deploy: SQS-driven `_upsert_mentor` / `_put_mentor` still index profiles correctly (verify with a `PUT /v1/mentors/mentor_profile` upstream → SQS → OpenSearch round-trip)
- [ ] `GET /v1/search/mentors?filter_skills=...` returns results
- [ ] `GET /v1/search/mentors?filter_offers=...` returns results
- [ ] `GET /v1/search/mentors?filter_expertises=...` still returns results (kept for backward compat)
- [ ] `GET /v1/search/mentors/{user_id}` returns the clean profile shape (no `interested_positions / skills / topics / expertises` keys)

🤖 Generated with [Claude Code](https://claude.com/claude-code)