### PR TITLE
refactor(experiences): drop PATCH path, force empty arrays through to_json

### DIFF
--- a/src/config/constant.py
+++ b/src/config/constant.py
@@ -50,6 +50,5 @@ class Sorting(Enum):
 
 class MentorAction(str, Enum):
     UPSERT_MENTOR_PROFILE = "UPSERT_MENTOR_PROFILE"  # PUT /users/profile
-    PUT_MENTOR_PROFILE    = "PUT_MENTOR_PROFILE"      # PUT /mentors/mentor_profile
-    PATCH_MENTOR_PROFILE  = "PATCH_MENTOR_PROFILE"    # PUT|DELETE /mentors/{id}/experiences
+    PUT_MENTOR_PROFILE    = "PUT_MENTOR_PROFILE"      # PUT /mentors/mentor_profile (carries experiences inline)
     DELETE_MENTOR_PROFILE = "DELETE_MENTOR_PROFILE"   # future: delete mentor account

--- a/src/domain/mentor/model/experience_model.py
+++ b/src/domain/mentor/model/experience_model.py
@@ -8,14 +8,12 @@ log = logging.getLogger(__name__)
 
 
 class ExperienceDTO(BaseModel):
-    id: Optional[int] = None
     category: ExperienceCategory = None
     mentor_experiences_metadata: Dict = {}
     order: int = 0
 
 
 class ExperienceVO(BaseModel):
-    id: int
     category: ExperienceCategory = None
     mentor_experiences_metadata: Dict = {}
     order: int = 0

--- a/src/domain/mentor/model/mentor_model.py
+++ b/src/domain/mentor/model/mentor_model.py
@@ -42,6 +42,16 @@ class MentorProfileDTO(ProfileDTO):
     # Fields that exist only for SQS routing and must never be persisted to OpenSearch.
     _EXCLUDE_FROM_DOC = {"action"}
 
+    # Fields that must be sent even when empty so doc_as_upsert can clear them.
+    # Skipping empty arrays leaves stale values in OpenSearch — e.g. a mentor
+    # who clears all experiences would still match nested experience filters
+    # against the previous list.
+    _ALWAYS_INCLUDE_IF_EMPTY = {
+        "experiences",
+        "want_position", "want_skill", "want_topic",
+        "have_skill", "have_topic",
+    }
+
     def to_json(self) -> Dict:
         dao_dict = {}
         for key in self.model_fields.keys():
@@ -51,7 +61,7 @@ class MentorProfileDTO(ProfileDTO):
             if value is None:
                 continue
             elif isinstance(value, (list, dict)):
-                if len(value) == 0:
+                if len(value) == 0 and key not in self._ALWAYS_INCLUDE_IF_EMPTY:
                     continue
             elif isinstance(value, Enum):
                 dao_dict[key] = value.value

--- a/src/domain/search/service/search_service.py
+++ b/src/domain/search/service/search_service.py
@@ -1,6 +1,7 @@
 from datetime import datetime, timezone
 from typing import Callable, Dict
 
+
 from ....infra.api.opensearch import OpenSearch
 from ....domain.mentor.model.mentor_model import MentorProfileDTO
 from ....domain.search.model.search_model import SearchMentorProfileDTO
@@ -19,7 +20,6 @@ class SearchService:
         self._command_registry: Dict[MentorAction, Callable] = {
             MentorAction.UPSERT_MENTOR_PROFILE: self._upsert_mentor,
             MentorAction.PUT_MENTOR_PROFILE:    self._put_mentor,
-            MentorAction.PATCH_MENTOR_PROFILE:  self._patch_mentor_experiences,
             MentorAction.DELETE_MENTOR_PROFILE: self._delete_mentor_by_event,
         }
 
@@ -53,28 +53,12 @@ class SearchService:
         await self.send_mentor(body)
 
     async def _put_mentor(self, event: Dict):
-        """Update mentor-specific fields (personal_statement, about, seniority_level,
-        tag buckets).  Uses the same _update + doc_as_upsert path so OpenSearch
-        merges only the supplied fields."""
+        """Update mentor-specific fields including experiences and tag buckets.
+        Uses _update + doc_as_upsert; mentor_model.to_json forces empty arrays
+        to ride along so doc_as_upsert can clear cleared fields rather than
+        leaving stale values from the previous version of the document."""
         body = MentorProfileDTO(**event)
         await self.send_mentor(body)
-
-    async def _patch_mentor_experiences(self, event: Dict):
-        """Partial update: replace only the `experiences` nested array and bump
-        updated_at.  Does NOT touch any other profile fields."""
-        user_id = event.get("user_id")
-        experiences = event.get("experiences", [])
-        now_iso = datetime.now(timezone.utc).isoformat()
-        patch_body = {
-            "doc": {
-                "experiences": experiences,
-                "updated_at": now_iso,
-            }
-        }
-        response: ClientResponse = await self.opensearch.post(
-            f"/profiles/_update/{user_id}", json=patch_body
-        )
-        return response.res_json
 
     async def _delete_mentor_by_event(self, event: Dict):
         """Hard-delete the mentor profile document from the index."""

--- a/src/infra/opensearch/mapping.py
+++ b/src/infra/opensearch/mapping.py
@@ -52,7 +52,6 @@ PROFILES_INDEX_MAPPING: Dict = {
             "experiences": {
                 "type": "nested",
                 "properties": {
-                    "id": {"type": "integer"},
                     "category": {"type": "keyword"},
                     "order": {"type": "integer"},
                     "mentor_experiences_metadata": {"type": "object", "dynamic": True},


### PR DESCRIPTION
## Summary
- Drops `MentorAction.PATCH_MENTOR_PROFILE`, `_patch_mentor_experiences` handler, and the registry binding. Experiences now ride inline on `PUT_MENTOR_PROFILE` messages from User, so the dedicated PATCH path is dead.
- Drops the per-experience `id` field from the OpenSearch nested mapping and the `ExperienceVO/DTO` (User no longer carries a row id).
- **Critical fix in `MentorProfileDTO.to_json()`**: previously empty lists/dicts were skipped entirely. Combined with `doc_as_upsert: True`, this meant a mentor clearing all experiences would never overwrite the existing nested array — old rows lingered and matched nested filters. Same bug for the five tag-bucket arrays. `_ALWAYS_INCLUDE_IF_EMPTY` now forces those six fields to ride along even when empty.

## Coordinated changes
- X-Career-User PR #114: experiences move to `profiles.experiences` JSONB[]; `notify_updated_user_experiences` (the `PATCH_MENTOR_PROFILE` publisher) is removed.
- X-Career-BFF PR: mirrors inline `experiences` on the DTO, drops `/experiences` proxy endpoints.
- X-Talent-Frontend PR: switches to inline experiences on the profile PUT.

## Test plan
- [x] `docker compose up`, POST `/v1/internal/mentor` with `experiences: []` → OpenSearch doc transitions from 3 nested entries to `[]` in a single PUT (was the broken case before this fix).
- [x] OpenSearch mapping check: `experiences.properties` no longer carries `id`.
- [x] No `_patch_mentor_experiences` references remain; command registry only handles UPSERT / PUT / DELETE.

🤖 Generated with [Claude Code](https://claude.com/claude-code)