### PR TITLE
fix(main): keep event loop on thread after SQS handler (root cause: GET /search/mentors 502 on dev)

### DIFF
--- a/main.py
+++ b/main.py
@@ -105,5 +105,20 @@ def _handle_sqs_event(event):
                 )
                 failures.append({"itemIdentifier": record["messageId"]})
 
-    asyncio.run(_process_all())
+    # Don't use asyncio.run() — on exit it calls events.set_event_loop(None)
+    # and closes the loop. Once set_event_loop has been called even once on a
+    # thread, Python 3.9's asyncio.get_event_loop() refuses to auto-create a
+    # new loop and raises "RuntimeError: There is no current event loop in
+    # thread 'MainThread'". Mangum.LifespanCycle.__init__ calls exactly that
+    # function, so the *next* HTTP invocation in the same warm Lambda container
+    # would 502 — and every subsequent HTTP invocation in that container too.
+    try:
+        loop = asyncio.get_event_loop()
+        if loop.is_closed():
+            raise RuntimeError("loop closed")
+    except RuntimeError:
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+
+    loop.run_until_complete(_process_all())
     return {"batchItemFailures": failures}


### PR DESCRIPTION
﻿## Summary

- Fix Search Lambda 502s on every HTTP invocation that follows an SQS event in the same warm container.
- Triggered by a real outage today: `GET /search-service/api/v1/search/mentors` returned 502 Bad Gateway, so mentor-pool page came up empty even when sync to OpenSearch had succeeded.

## Root cause

CloudWatch on `x-career-search-dev-app` showed:

\\\
[ERROR] RuntimeError: There is no current event loop in thread 'MainThread'.
Traceback (most recent call last):
  File "/var/task/main.py", line 89, in handler
    return _mangum(event, context)
  File "/opt/python/mangum/adapter.py", line 66, in __call__
    lifespan_cycle = LifespanCycle(self.app, self.lifespan)
  File "/opt/python/mangum/protocols/lifespan.py", line 62, in __init__
    self.loop = asyncio.get_event_loop()
\\\

Timeline matched perfectly:
- 00:30:33 / 00:31:15 / 00:32:38 — SQS PUT_MENTOR_PROFILE events arrived from User after a mentor profile write, `_handle_sqs_event` ran `asyncio.run(_process_all())` and exited successfully.
- 00:40:29 onwards — every HTTP invocation in the same warm container 502'd with the RuntimeError above.

`asyncio.run` calls `events.set_event_loop(None)` and `loop.close()` on exit. Python 3.9's `asyncio.get_event_loop()` refuses to auto-create a loop on the main thread once `set_event_loop` has been called even once (the policy's `_set_called` flag is sticky), so the next call raises. Mangum's `LifespanCycle.__init__` calls exactly that.

This service routes both SQS and HTTP events through the same `handler()` (PR #29 added the SQS path), so the two share a Lambda container. One SQS batch poisons all subsequent HTTP requests on that container until it dies of idle timeout.

## Fix

Manage the loop ourselves instead of using `asyncio.run`: reuse an open loop if one exists on the thread, otherwise create one and `set_event_loop` it once. Don't unset it on exit. Mangum can then grab the same loop on its next call.

Loop reuse across SQS invocations is fine — each invocation calls `run_until_complete` which doesn't close the loop, and our coroutine doesn't hold cross-invocation state.

## Test plan

- [ ] Merge to `dev`, let CI redeploy
- [ ] Trigger an SQS sync (e.g. PUT a mentor profile via User service)
- [ ] Immediately hit `GET /dev/search-service/api/v1/search/mentors` from the same warm container — expect 200 with mentor list
- [ ] Repeat several times; CloudWatch should show no `RuntimeError: There is no current event loop` lines in the Search log group
