### PR TITLE
fix(search): map filter_skills/filter_topics to HAVE-side fields (mentor-pool empty results)

### DIFF
--- a/src/router/req/search.py
+++ b/src/router/req/search.py
@@ -11,12 +11,19 @@ def format_search_mentors_query(query: SearchMentorProfileDTO):
     }
 
     if query.filter_skills:
+        # mentor-pool search: the FE sources its skill dropdown from
+        # tagCatalog.have_skill (mentor-pool/container.tsx), so a user
+        # picking "X" expects "mentors who can teach X" — the HAVE side.
+        # Querying want_skill (mentor wants to learn X) returned 0 hits
+        # for every realistic pick.
         query_body["query"]["bool"]["must"].append(
-            {"terms": {"want_skill": query.filter_skills}}
+            {"terms": {"have_skill": query.filter_skills}}
         )
     if query.filter_topics:
+        # Same mismatch as filter_skills above — FE sources from
+        # tagCatalog.have_topic, so HAVE-side is the right field.
         query_body["query"]["bool"]["must"].append(
-            {"terms": {"want_topic": query.filter_topics}}
+            {"terms": {"have_topic": query.filter_topics}}
         )
     if query.filter_positions:
         query_body["query"]["bool"]["must"].append(


### PR DESCRIPTION
﻿## Summary

- Mentor-pool search returned empty for every realistic skill/topic pick on dev. Root cause: `filter_skills` and `filter_topics` queried the WANT-side OpenSearch fields, but the FE sources its dropdown options from the HAVE-side catalog -- WANT/HAVE was inverted.
- Switch both filters to query the matching HAVE-side field. Two-line change in `format_search_mentors_query`.

## Root cause

The frontend container hard-codes the dropdown source for these filters
(`frontend/X-Talent-Frontend/src/app/mentor-pool/container.tsx:78-85`):

\\\	sx
filter_skills: { options: subjectsToOptions(flattenLeaves(tagCatalog.have_skill)) },
filter_topics: { options: subjectsToOptions(flattenLeaves(tagCatalog.have_topic)) },
\\\

So when a user picks "X" from the skill dropdown, the intent is "find mentors who can teach X" -- the HAVE side. The backend was sending `{"terms": {"want_skill": [...]}}` to OpenSearch, which asks "find mentors who want to learn X". For mentor-pool semantics those are the opposite question.

Verified directly against dev OpenSearch with one mentor's actual data:

\\\
mentor.want_skill = ['user_interview']
mentor.have_skill = ['ad_placement']

GET /search/mentors?filter_skills=user_interview   -> 1 result  (matches WANT)
GET /search/mentors?filter_skills=ad_placement     -> 0 results (HAVE, missed)
\\\

Same pattern for topics:

\\\
mentor.want_topic = ['interview_skills']
mentor.have_topic = ['cross_team_collab']

GET /search/mentors?filter_topics=interview_skills -> 1 result  (matches WANT)
GET /search/mentors?filter_topics=cross_team_collab -> 0 results (HAVE, missed)
\\\

So every pick from the FE dropdown landed on the HAVE side and missed the WANT-side query.

## Fix

In `src/router/req/search.py`, change the OpenSearch field for these two filters:

- `filter_skills` -> `have_skill` (was `want_skill`)
- `filter_topics` -> `have_topic` (was `want_topic`)

Comments inline reference the FE source so this doesn't get silently flipped back.

## Notes

- `filter_expertises` already queries `have_skill`; `filter_offers` queries `have_skill OR have_topic`. After this PR they overlap with `filter_skills`/`filter_topics` semantically -- fine, the FE picks one entry point per surface. We can deprecate the duplicates in a follow-up if anyone wants tighter naming.
- `filter_positions` still maps to `want_position`. The mentor-pool FE doesn't currently expose a position filter, so I'm leaving that for whoever introduces that surface to decide intent.
- `filter_industries` is a flat field on `profile.industry` and was already correct -- verified `filter_industries=mining_quarrying` returns the expected mentor.

## Test plan

- [ ] Merge to `dev`, let CI redeploy
- [ ] On mentor-pool page, pick a skill that some mentor has in `have_skill` -> expect that mentor in the result list
- [ ] Same for topic
- [ ] Sanity: `filter_industries` and `search_pattern` still return the same mentors as before
